### PR TITLE
AAZM-692

### DIFF
--- a/mappFramework/Logical/UnitTestVC4/Backup/BackupUnitTest/Set_BackupMgr.c
+++ b/mappFramework/Logical/UnitTestVC4/Backup/BackupUnitTest/Set_BackupMgr.c
@@ -29,15 +29,31 @@ _TEARDOWN_TEST(void)
 	TEST_DONE;
 }
 
+_TEST createNotAllowedInSim(void)
+{
+	TEST_ABORT_CONDITION(!HmiBackup.Status.SimulationActive);
+	TEST_ASSERT(!HmiBackup.Status.CreateAllowed);
+	TEST_DONE;
+}
+
+_TEST restoreNotAllowedInSim(void)
+{
+	TEST_ABORT_CONDITION(!HmiBackup.Status.SimulationActive);
+	TEST_ASSERT(!HmiBackup.Status.RestoreAllowed);
+	TEST_DONE;
+}
+
 /*
 B+R UnitTest: This is generated code.
 Do not edit! Do not move!
 Description: UnitTest Testprogramm infrastructure (TestSet).
-LastUpdated: 2022-09-22 14:29:52Z
+LastUpdated: 2023-09-05 18:15:00Z
 By B+R UnitTest Helper Version: 2.0.1.59
 */
 UNITTEST_FIXTURES(fixtures)
 {
+	new_TestFixture("createNotAllowedInSim", createNotAllowedInSim), 
+	new_TestFixture("restoreNotAllowedInSim", restoreNotAllowedInSim), 
 };
 
 UNITTEST_CALLER_COMPLETE_EXPLICIT(Set_BackupMgr, "Set_BackupMgr", setupTest, teardownTest, fixtures, setupSet, teardownSet, 0);

--- a/mappFramework/Physical/UnitTestVC4/PC_any/UnitTest/BackupMgr.vvm
+++ b/mappFramework/Physical/UnitTestVC4/PC_any/UnitTest/BackupMgr.vvm
@@ -2,4 +2,7 @@ VAR_CONFIG
 	::BackupMgr:MpBackupCoreSys.StatusID AT %Q.::BackupUnit:MpBlockStatus[0]; (*Insert your comment here...*)
 	::BackupMgr:MpBackupCoreConfigSys.StatusID AT %Q.::BackupUnit:MpBlockStatus[1]; (*Insert your comment here...*)
 	::BackupMgr:MpFileManagerUIBackup.StatusID AT %Q.::BackupUnit:MpBlockStatus[2]; (*Insert your comment here...*)
+	::BackupMgr:HmiBackup.Status AT %Q.::BackupUnit:HmiBackup.Status; (*Insert your comment here...*)
+	::BackupUnit:HmiBackup.Commands AT %Q.::BackupMgr:HmiBackup.Commands; (*Insert your comment here...*)
+	::BackupUnit:HmiBackup.Parameters AT %Q.::BackupMgr:HmiBackup.Parameters; (*Insert your comment here...*)
 END_VAR


### PR DESCRIPTION
add VC4 specific unit tests

Note: that there were no unit tests for mapp View other than the standard checks.  I added 2 for checking that the create and restore buttons are disabled when in simulation