### PR TITLE
AAZM-697 - VC4 recipe UT was failing due to simultaneous Load cmds on…

### DIFF
--- a/mappFramework/Logical/Infrastructure/VC4/Recipe/RecipeMgr/HMIActions.st
+++ b/mappFramework/Logical/Infrastructure/VC4/Recipe/RecipeMgr/HMIActions.st
@@ -143,9 +143,9 @@ ACTION LoadPreview:
 	END_IF;
 		
 	// Load preview when a recipe is selected
-	IF (MpRecipeUIConnect.Recipe.List.SelectedIndex <> HmiRecipe.Status.LastSelectedIndex) OR 
+	IF ((MpRecipeUIConnect.Recipe.List.SelectedIndex <> HmiRecipe.Status.LastSelectedIndex) OR 
 		(HmiRecipe.Status.LastMaxSelection <> MpRecipeUIConnect.Recipe.List.MaxSelection) OR
-		EDGENEG(HmiRecipe.Status.LastStatus = mpRECIPE_UI_STATUS_CREATE) THEN		
+		EDGENEG(HmiRecipe.Status.LastStatus = mpRECIPE_UI_STATUS_CREATE)) AND NOT MpRecipeUIConnect.Recipe.Load THEN		
 		// Check selected recipe name is not empty
 		IF (brsstrlen(ADR(MpRecipeUIConnect.Recipe.List.Names[MpRecipeUIConnect.Recipe.List.SelectedIndex])) > 0) THEN
 			MpRecipeSys.FileName := ADR(MpRecipeUIConnect.Recipe.List.Names[MpRecipeUIConnect.Recipe.List.SelectedIndex]);

--- a/mappFramework/Logical/UnitTestVC4/Recipe/RecipeMgrUnitTest/Set_RecipeParameters.c
+++ b/mappFramework/Logical/UnitTestVC4/Recipe/RecipeMgrUnitTest/Set_RecipeParameters.c
@@ -300,6 +300,7 @@ _TEST PreviewShouldNotAffectActive(void)
 					break;
 
 				case 4:
+					TEST_BUSY_CONDITION(MpRecipeSys.Load == true);
 					TEST_BUSY_CONDITION(!SelectRecipe("preview.par"));
 					MpRecipeUIConnect.Recipe.Load = true;
 					TEST_BUSY_CONDITION(MpRecipeUIConnect.Status != mpRECIPE_UI_STATUS_LOAD);
@@ -378,6 +379,7 @@ _TEST Preview(void)
 					break;
 
 				case 4:
+					TEST_BUSY_CONDITION(MpRecipeSys.Load == true);
 					TEST_BUSY_CONDITION(!SelectRecipe("preview.par"));
 					MpRecipeUIConnect.Recipe.Load = true;
 					TEST_BUSY_CONDITION(MpRecipeUIConnect.Status != mpRECIPE_UI_STATUS_LOAD);


### PR DESCRIPTION
… UIConnect and FB interface

Added a busy condition for the UT to wait until the FB Load is false.