### PR TITLE
update VC4 unit test names so that they will show up in different suites

### DIFF
--- a/mappFramework/Logical/UnitTestVC4/AlarmX/AlarmXUnitTest/variables.var
+++ b/mappFramework/Logical/UnitTestVC4/AlarmX/AlarmXUnitTest/variables.var
@@ -10,7 +10,7 @@
  ********************************************************************)
 (*Describe the test*)
 VAR
-	Testsuite : UtMgrTestSuite := (Name:='AlarmMgr',Description:='AlarmMgr Unit Tests',MetaInformation:='Meta');
+	Testsuite : UtMgrTestSuite := (Name:='AlarmMgrVC4',Description:='AlarmMgr VC4 Unit Tests',MetaInformation:='Meta');
 END_VAR
 (*Variables used in the tests*)
 VAR

--- a/mappFramework/Logical/UnitTestVC4/AppAxis_1/AppAxisUnitTest/variables.var
+++ b/mappFramework/Logical/UnitTestVC4/AppAxis_1/AppAxisUnitTest/variables.var
@@ -10,7 +10,7 @@
  ********************************************************************)
 (*Describe the test*)
 VAR
-	Testsuite : UtMgrTestSuite := (Name:='AppAxis_1',Description:='AppAxis_1 Unit Tests',MetaInformation:='Meta');
+	Testsuite : UtMgrTestSuite := (Name:='AppAxis_1VC4',Description:='AppAxis_1 VC4 Unit Tests',MetaInformation:='Meta');
 END_VAR
 (*Variables used in the tests*)
 VAR

--- a/mappFramework/Logical/UnitTestVC4/Audit/AuditTest/variables.var
+++ b/mappFramework/Logical/UnitTestVC4/Audit/AuditTest/variables.var
@@ -10,7 +10,7 @@
  ********************************************************************)
 (*Describe the test*)
 VAR
-	Testsuite : UtMgrTestSuite := (Name:='AuditMgr',Description:='AuditMgr Unit Tests',MetaInformation:='Meta');
+	Testsuite : UtMgrTestSuite := (Name:='AuditMgrVC4',Description:='AuditMgr VC4 Unit Tests',MetaInformation:='Meta');
 END_VAR
 (*Variables used in the tests*)
 VAR

--- a/mappFramework/Logical/UnitTestVC4/Backup/BackupUnitTest/variables.var
+++ b/mappFramework/Logical/UnitTestVC4/Backup/BackupUnitTest/variables.var
@@ -10,6 +10,6 @@
  ********************************************************************)
 (*Describe the test*)
 VAR
-	Testsuite : UtMgrTestSuite := (Name:='BackupMgr',Description:='BackupMgr Unit Tests',MetaInformation:='Meta');
+	Testsuite : UtMgrTestSuite := (Name:='BackupMgrVC4',Description:='BackupMgr VC4 Unit Tests',MetaInformation:='Meta');
 END_VAR
 (*Variables used in the tests*)

--- a/mappFramework/Logical/UnitTestVC4/File/FileUnitTest/variables.var
+++ b/mappFramework/Logical/UnitTestVC4/File/FileUnitTest/variables.var
@@ -10,7 +10,7 @@
  ********************************************************************)
 (*Describe the test*)
 VAR
-	Testsuite : UtMgrTestSuite := (Name:='FileMgr',Description:='FileMgr Unit Tests',Type:=utMgrTEST_TYPE_C,MetaInformation:='Meta');
+	Testsuite : UtMgrTestSuite := (Name:='FileMgrVC4',Description:='FileMgr VC4 Unit Tests',Type:=utMgrTEST_TYPE_C,MetaInformation:='Meta');
 END_VAR
 (*Variables used in the tests*)
 VAR

--- a/mappFramework/Logical/UnitTestVC4/Recipe/RecipeMgrUnitTest/variables.var
+++ b/mappFramework/Logical/UnitTestVC4/Recipe/RecipeMgrUnitTest/variables.var
@@ -10,7 +10,7 @@
  ********************************************************************)
 (*Describe the test*)
 VAR
-	Testsuite : UtMgrTestSuite := (Name:='RecipeMgr',Description:='RecipeMgr Unit Tests',MetaInformation:='Meta');
+	Testsuite : UtMgrTestSuite := (Name:='RecipeMgrVC4',Description:='RecipeMgr VC4 Unit Tests',MetaInformation:='Meta');
 END_VAR
 (*Variables used in the tests*)
 VAR

--- a/mappFramework/Logical/UnitTestVC4/Report/ReportUnitTest/variables.var
+++ b/mappFramework/Logical/UnitTestVC4/Report/ReportUnitTest/variables.var
@@ -10,7 +10,7 @@
  ********************************************************************)
 (*Describe the test*)
 VAR
-	Testsuite : UtMgrTestSuite := (Name:='ReportMgr',Description:='ReportMgr Unit Tests',MetaInformation:='Meta');
+	Testsuite : UtMgrTestSuite := (Name:='ReportMgrVC4',Description:='ReportMgr VC4 Unit Tests',MetaInformation:='Meta');
 END_VAR
 (*Variables used in the tests*)
 VAR

--- a/mappFramework/Logical/UnitTestVC4/UserX/UserXUnitTest/variables.var
+++ b/mappFramework/Logical/UnitTestVC4/UserX/UserXUnitTest/variables.var
@@ -11,7 +11,7 @@
 (*Describe the test*)
 VAR
 	TestStep : USINT;
-	Testsuite : UtMgrTestSuite := (Name:='UserMgr',Description:='UserMgr Unit Tests',MetaInformation:='Meta');
+	Testsuite : UtMgrTestSuite := (Name:='UserMgrVC4',Description:='UserMgr VC4 Unit Tests',MetaInformation:='Meta');
 END_VAR
 (*Variables used in the tests*)
 VAR


### PR DESCRIPTION
I renamed the name of the unit tests for VC4 so that we won't appear to have duplicate tests when viewed in jenkins