### PR TITLE
AAZM-738 - fixed text system references for alarms 

### DIFF
--- a/mappFramework/Logical/Infrastructure/Report/ReportMgr/ReportMgr.st
+++ b/mappFramework/Logical/Infrastructure/Report/ReportMgr/ReportMgr.st
@@ -10,8 +10,13 @@ PROGRAM _INIT
 	// Create folder for this component on the user file device
 	DirCreateReport(enable := TRUE, pDevice := ADR('mappReportFiles'), pName := ADR('/'));
 
+	// Wait for DirCreateReport to complete.
+	WHILE (DirCreateReport.status = ERR_FUB_BUSY) DO
+		DirCreateReport();
+	END_WHILE
+	
 	// Check if folder already exist and if so disabled the function block call
-	IF DirCreateReport.status = fiERR_DIR_ALREADY_EXIST THEN
+	IF DirCreateReport.status = fiERR_DIR_ALREADY_EXIST OR (DirCreateReport.status = ERR_OK) THEN
 		DirCreateReport(enable := FALSE);
 	END_IF
 	
@@ -24,12 +29,6 @@ PROGRAM _INIT
 	HmiReport.Parameters.SortType := 'NameAsc';
 	MpReportCoreSys();
 
-	MpFileManagerUIReport.MpLink := ADR(gMpLinkFileManagerUIReport);
-	MpFileManagerUIReport.UIConnect := ADR(MpFileManagerUIConnect);
-	MpFileManagerUIReport.UISetup.FileListSize := SIZEOF(MpFileManagerUIConnect.File.List.Items) / SIZEOF(MpFileManagerUIConnect.File.List.Items[0]);
-	MpFileManagerUIReport.Enable := TRUE;
-	MpFileManagerUIReport();
-	
 	MpFileManagerUIConnect.DeviceList.DeviceNames[0] := 'mappReportFiles';
 	MpFileManagerUIConnect.DeviceList.DeviceNames[1] := '';
 	MpFileManagerUIConnect.DeviceList.DeviceNames[2] := '';
@@ -40,6 +39,12 @@ PROGRAM _INIT
 	MpFileManagerUIConnect.DeviceList.DeviceNames[7] := '';
 	MpFileManagerUIConnect.DeviceList.DeviceNames[8] := '';
 	MpFileManagerUIConnect.DeviceList.DeviceNames[9] := '';
+	
+	MpFileManagerUIReport.MpLink := ADR(gMpLinkFileManagerUIReport);
+	MpFileManagerUIReport.UIConnect := ADR(MpFileManagerUIConnect);
+	MpFileManagerUIReport.UISetup.FileListSize := SIZEOF(MpFileManagerUIConnect.File.List.Items) / SIZEOF(MpFileManagerUIConnect.File.List.Items[0]);
+	MpFileManagerUIReport.Enable := TRUE;
+	MpFileManagerUIReport();
 
 	// Fill an array to create example data for the example report
 	TimeIndex := 0;

--- a/mappFramework/Physical/Simulation/PC/mappServices/Report/ReportFile.mpfilemanagerui
+++ b/mappFramework/Physical/Simulation/PC/mappServices/Report/ReportFile.mpfilemanagerui
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+<?AutomationStudio FileVersion="4.9"?>
 <Configuration>
   <Element ID="gMpLinkFileManagerUIReport" Type="mpfilemanagerui">
     <Group ID="FileMan">
@@ -9,13 +10,13 @@
     <Selector ID="Alarms" Value="MpAlarmX">
       <Group ID="mapp.AlarmX.Core.Configuration">
         <Group ID="[0]">
-          <Property ID="Message" Value="{$File/Alarms/DeviceNotFound}" />
+          <Property ID="Message" Value="Report - {$mappFramework/File/Alarms/DeviceNotFound} " />
         </Group>
         <Group ID="[1]">
-          <Property ID="Message" Value="{$File/Alarms/AlreadyExisting}" />
+          <Property ID="Message" Value="Report - {$mappFramework/File/Alarms/AlreadyExisting}" />
         </Group>
         <Group ID="[2]">
-          <Property ID="Message" Value="{$File/Alarms/FileSystemError}" />
+          <Property ID="Message" Value="Report - {$mappFramework/File/Alarms/FileSystemError}" />
         </Group>
       </Group>
     </Selector>


### PR DESCRIPTION
and the source of the error which was caused by calling the FileManagerUI without having the DeviceList initialized.

I also copied the DirCreate code from recipe so that the INIT will "wait" till the FB is done creating before trying to access it in the FileManager