### PR TITLE
Unit tests failed sometimes

### DIFF
--- a/mappFramework/Logical/UnitTest/File/FileUnitTest/Set_FileMgr.c
+++ b/mappFramework/Logical/UnitTest/File/FileUnitTest/Set_FileMgr.c
@@ -1201,8 +1201,13 @@ _TEST Cut_Paste_Directory(void)
 				case 3:
 					TEST_BUSY_CONDITION(pMpFileManagerUIConnect->Status != mpFILE_UI_STATUS_REFRESH);
 					pMpFileManagerUIConnect->File.Refresh = 0;
-					ArrangeSubState = 10;
+					ArrangeSubState = 4;
 					break;
+				
+				case 4:
+					TEST_BUSY_CONDITION(pMpFileManagerUIConnect->Status != mpFILE_UI_STATUS_IDLE);
+					ArrangeSubState = 10;
+					break;				
 				
 				case 10:
 					brsmemcpy((UDINT)&pMpFileManagerUIConnect->File.NewName, (UDINT)&NewDirName, sizeof(pMpFileManagerUIConnect->File.NewName));

--- a/mappFramework/Logical/UnitTest/File/FileUnitTest/Set_FileMgr.c
+++ b/mappFramework/Logical/UnitTest/File/FileUnitTest/Set_FileMgr.c
@@ -1206,7 +1206,7 @@ _TEST Cut_Paste_Directory(void)
 				
 				case 10:
 					brsmemcpy((UDINT)&pMpFileManagerUIConnect->File.NewName, (UDINT)&NewDirName, sizeof(pMpFileManagerUIConnect->File.NewName));
-					pMpFileManagerUIConnect->File.CreateFolder = 11;
+					pMpFileManagerUIConnect->File.CreateFolder = 1;
 					ArrangeSubState = 11;
 					break;
 							


### PR DESCRIPTION
Sometimes the unit test worked, sometimes it failed at **_TEST Cut_Paste_Directory(void)**

waiting for IDLE state after refresh command helps, otherwise next commands can get lost